### PR TITLE
Refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX=g++
 CXXLIBS=$(shell pkg-config --libs sylvan)
-CXXFLAGS=-O2 -shared -fPIC -g
+CXXFLAGS=-std=c++20 -O2 -shared -fPIC -g
 
 .PHONY := clean
 
@@ -28,8 +28,7 @@ build:
 	-mkdir build
 
 clean:
-	rm build/*
-
+	rm build/* || true
 
 build/test.o: src/test.cpp include/hopcroft_leaf.hpp
 	$(CXX) -c $(CXXFLAGS) src/test.cpp -o build/test.o

--- a/include/base.hpp
+++ b/include/base.hpp
@@ -22,12 +22,11 @@ typedef int64_t State;
 
 class Transition_Destination_Set {
 public:
-	std::set<State>* destination_set;
+	std::set<State> destination_set;
 
-	Transition_Destination_Set();
+	Transition_Destination_Set() {};
 	Transition_Destination_Set(const Transition_Destination_Set &other);
-	Transition_Destination_Set(std::set<State>* destination_set);
-	~Transition_Destination_Set();
+	Transition_Destination_Set(std::set<State>& destination_set);
 	void print_dest_states();
 };
 

--- a/include/operations.hpp
+++ b/include/operations.hpp
@@ -47,13 +47,11 @@ typedef struct
 typedef struct
 {
 	bool had_effect;
-	uint32_t automaton_id;
 	State trapstate;
 } Complete_With_Trapstate_Op_Info;
 
 typedef struct
 {
-	uint32_t automaton_id;
 	std::vector<State> *discoveries; // Flat array of [macrostate_left_part, macrostate_right_part, state, ...]
 } Intersection_Op_Info;
 

--- a/include/wrapper.hpp
+++ b/include/wrapper.hpp
@@ -22,10 +22,7 @@ extern "C" {
 	const sylvan::MTBDD w_mtbdd_false = sylvan::mtbdd_false;
 
 	// Functions
-	sylvan::MTBDD amaya_unite_mtbdds(
-			sylvan::MTBDD m1, 
-			sylvan::MTBDD m2,
-			uint32_t automaton_id);
+	sylvan::MTBDD amaya_unite_mtbdds(sylvan::MTBDD m1, sylvan::MTBDD m2);
 
 	sylvan::MTBDD amaya_project_variables_away(
 			sylvan::MTBDD m, 
@@ -41,7 +38,6 @@ extern "C" {
 	void amaya_print_dot(sylvan::MTBDD m, int32_t fd);
 
 	sylvan::MTBDD amaya_mtbdd_build_single_terminal(
-		uint32_t  automaton_id,
 		uint8_t*  transition_symbols,  // 2D array of size (variable_count) * transition_symbols_count
 		uint32_t  transition_symbols_count,
 		uint32_t  variable_count,
@@ -77,19 +73,6 @@ extern "C" {
 			void* 	 leaf_tds, 
 			State* 	 new_leaf_contents, 
 			uint32_t contents_size);
-
-	/**
-	 * Given an arary of MTBDD roots, collects their leaves and changes their automaton id
-	 * to `new_id`. Should be called after a new automaton is a result of automaton union.
-	 *
-	 * @param roots 	The array of mtbdds roots.
-	 * @param root_cnt 	The number of roots in the `roots` array.
-	 * @param new_id 	New automaton identifier for the leaves.
-	 */
-	void amaya_mtbdd_change_automaton_id_for_leaves(
-			sylvan::MTBDD* roots,
-			uint32_t root_cnt,
-			uint32_t new_id);
 
 	/**
 	 * Calculates the post set from given MTBDD.
@@ -138,8 +121,6 @@ extern "C" {
 	 * Calculate the intersection of two mtbdds (Operation on leaves is set intersection).
 	 * @param a 				Some transition MTBDD
 	 * @param b 				Other transition MTBDD
-	 * @param new_automaton_id 	Automaton ID for the created intersect leaves.
-	 *
 	 * @param discovered_states 		Flat array of discovered macrostates and their generated int.
 	 * 									[macrostate_left, macrostate_right, state_int ...]
 	 * @param discovered_states_cnt 	Discovered_states count (size/3).
@@ -148,7 +129,6 @@ extern "C" {
 	sylvan::MTBDD amaya_mtbdd_intersection(
 			sylvan::MTBDD a, 
 			sylvan::MTBDD b,
-			uint32_t 	result_automaton_id, 
 			State**  	discovered_states,         // OUT
 			uint32_t*  	discovered_states_cnt);    // OUT
 
@@ -188,7 +168,6 @@ extern "C" {
 	 * from the determinization procedure some automaton.
 	 * @param roots 					The roots of the MTBDDs that were created during the determinization procedure.  
 	 * @param root_cnt  				The number of given MTBDDs. 
-	 * @param resulting_automaton_id  	The ID of the resulting automaton.
 	 * @param out_macrostates_sizes   	OUTPUT: The sized of the located macrostates.
 	 * @param out_macrostates_cnt   		OUTPUT: The number of located macrostates.
 	 * @param out_serialized_macrostates OUTPUT: The macrostates located serialized one after another.
@@ -198,7 +177,6 @@ extern "C" {
 			sylvan::MTBDD* 		roots, 							// MTBDDs resulting from determinization
 			uint32_t 			root_cnt,						// Root count
 			State 				start_numbering_macrostates_from,
-			uint32_t 			resulting_automaton_id,
 			State**				out_serialized_macrostates,
 			uint64_t**			out_macrostates_sizes,
 			uint64_t*			out_macrostates_cnt);
@@ -206,7 +184,6 @@ extern "C" {
 
 	sylvan::MTBDD amaya_complete_mtbdd_with_trapstate(
 			sylvan::MTBDD mtbdd,
-			uint32_t 	automaton_id, 
 			State 		trapstate,
 			bool* 		had_effect);
 	

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -9,38 +9,24 @@
 using sylvan::MTBDD;
 using sylvan::mtbdd_support_CALL;
 
-Transition_Destination_Set::Transition_Destination_Set()
-{
-    this->destination_set = NULL;
-}
-
-Transition_Destination_Set::Transition_Destination_Set(const Transition_Destination_Set &other)
-{
+Transition_Destination_Set::Transition_Destination_Set(const Transition_Destination_Set &other) {
     // NOTE: Copy is called when a new leaf is created
-    this->destination_set = new std::set<State>(*other.destination_set);
+    this->destination_set = std::set<State>(other.destination_set);
 }
 
-Transition_Destination_Set::Transition_Destination_Set(std::set<State> *destination_set)
-{
+Transition_Destination_Set::Transition_Destination_Set(std::set<State>& destination_set) {
+    // @Cleanup: Check whether is is even called as it does a copy of the destination set,
+    //           and thus it is essentially the same as the copy constructor
     this->destination_set = destination_set;
 }
 
-Transition_Destination_Set::~Transition_Destination_Set()
-{
-    if (this->destination_set != NULL)
-    {
-        delete this->destination_set;
-    }
-}
-
-void Transition_Destination_Set::print_dest_states()
-{
+void Transition_Destination_Set::print_dest_states() {
     int cnt = 1;
     std::cout << "{";
-    for (auto state : *this->destination_set)
+    for (auto state : this->destination_set)
     {
         std::cout << state;
-        if (cnt < this->destination_set->size())
+        if (cnt < this->destination_set.size())
         {
             std::cout << ", ";
         }
@@ -92,10 +78,7 @@ void unpack_dont_care_bits_in_mtbdd_path(
     }
 }
 
-
-// @Unoptimized
-std::vector<struct Transition> nfa_unpack_transitions(struct NFA& nfa)
-{
+std::vector<struct Transition> nfa_unpack_transitions(struct NFA& nfa) {
     LACE_ME;
 
     std::vector<struct Transition> transitions;
@@ -109,7 +92,7 @@ std::vector<struct Transition> nfa_unpack_transitions(struct NFA& nfa)
 
         while (leaf != sylvan::mtbdd_false) {
             Transition_Destination_Set* tds = (Transition_Destination_Set*) sylvan::mtbdd_getvalue(leaf);
-            for (auto dest_state: *tds->destination_set) {
+            for (auto dest_state: tds->destination_set) {
                 unpack_dont_care_bits_in_mtbdd_path(path_in_mtbdd_to_leaf, nfa.var_count, transitions, 0, origin_state, dest_state);
             }
 
@@ -133,8 +116,7 @@ std::string transition_to_str(const struct Transition& transition) {
     return str_stream.str();
 }
 
-bool transition_is_same_as(const struct Transition& transition_a, const struct Transition& transition_b)
-{
+bool transition_is_same_as(const struct Transition& transition_a, const struct Transition& transition_b) {
     return transition_a.origin == transition_b.origin &&
            transition_a.destination == transition_b.destination &&
            transition_a.symbols == transition_b.symbols;

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -16,7 +16,8 @@ Transition_Destination_Set::Transition_Destination_Set()
 
 Transition_Destination_Set::Transition_Destination_Set(const Transition_Destination_Set &other)
 {
-    this->destination_set = new std::set<State>(*other.destination_set); // Do copy
+    // NOTE: Copy is called when a new leaf is created 
+    this->destination_set = new std::set<State>(*other.destination_set);
 }
 
 Transition_Destination_Set::Transition_Destination_Set(std::set<State> *destination_set)

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -16,7 +16,7 @@ Transition_Destination_Set::Transition_Destination_Set()
 
 Transition_Destination_Set::Transition_Destination_Set(const Transition_Destination_Set &other)
 {
-    // NOTE: Copy is called when a new leaf is created 
+    // NOTE: Copy is called when a new leaf is created
     this->destination_set = new std::set<State>(*other.destination_set);
 }
 
@@ -66,13 +66,13 @@ void unpack_dont_care_bits_in_mtbdd_path(
             dont_care_symbol_found = true;
             first_dont_care_symbol_index = i;
         }
-    } 
-    
+    }
+
     if (dont_care_symbol_found) {
-        uint8_t path_with_dont_care_bit_interpreted[path_size]; 
+        uint8_t path_with_dont_care_bit_interpreted[path_size];
         for (uint64_t i = 0; i < path_size; i++) path_with_dont_care_bit_interpreted[i] = mtbdd_path[i];
 
-        // Case split - interpret the don't care bit by setting first bit = 0, and then bit = 1 
+        // Case split - interpret the don't care bit by setting first bit = 0, and then bit = 1
         path_with_dont_care_bit_interpreted[first_dont_care_symbol_index] = 0;
         unpack_dont_care_bits_in_mtbdd_path(path_with_dont_care_bit_interpreted, path_size, unpacked_transitions, first_dont_care_symbol_index+1, origin, destination);
 
@@ -99,14 +99,14 @@ std::vector<struct Transition> nfa_unpack_transitions(struct NFA& nfa)
     LACE_ME;
 
     std::vector<struct Transition> transitions;
-    
+
     uint8_t* path_in_mtbdd_to_leaf = (uint8_t*) malloc(sizeof(uint8_t) * nfa.var_count);
     assert(path_in_mtbdd_to_leaf != NULL);
 
     for (auto origin_state: nfa.states) {
         MTBDD    state_transitions = nfa.transitions[origin_state];
         MTBDD    leaf         = sylvan::mtbdd_enum_first(state_transitions, nfa.vars, path_in_mtbdd_to_leaf, NULL);
-        
+
         while (leaf != sylvan::mtbdd_false) {
             Transition_Destination_Set* tds = (Transition_Destination_Set*) sylvan::mtbdd_getvalue(leaf);
             for (auto dest_state: *tds->destination_set) {

--- a/src/custom_leaf.cpp
+++ b/src/custom_leaf.cpp
@@ -45,7 +45,6 @@ int set_leaf_equals(uint64_t a_ptr, uint64_t b_ptr)
     Transition_Destination_Set *a_tds = (Transition_Destination_Set *)a_ptr;
     Transition_Destination_Set *b_tds = (Transition_Destination_Set *)b_ptr;
 
-    //if (a_tds->automaton_id == b_tds->automaton_id)
     if ((*a_tds->destination_set) == (*b_tds->destination_set))
     {
         return true;

--- a/src/custom_leaf.cpp
+++ b/src/custom_leaf.cpp
@@ -30,7 +30,7 @@ void mk_set_leaf(uint64_t *target_destination_set_ptr)
     Transition_Destination_Set *original_tds = (Transition_Destination_Set *)*target_destination_set_ptr;
     Transition_Destination_Set *new_tds = new Transition_Destination_Set(*original_tds); // Copy construct
 
-    // Accorting to the GMP leaf implementation, it should suffice to just write the new value to the state_set_ptr.
+    // According to the GMP leaf implementation, it should suffice to just write the new value to the state_set_ptr.
     *(Transition_Destination_Set **)target_destination_set_ptr = new_tds;
 }
 

--- a/src/custom_leaf.cpp
+++ b/src/custom_leaf.cpp
@@ -25,41 +25,34 @@ make_set_leaf(Transition_Destination_Set* value) {
  * copied to the hash table. This means that its a pointer to a poiter to a
  * vector.
  */
-void mk_set_leaf(uint64_t *target_destination_set_ptr)
-{
-    Transition_Destination_Set *original_tds = (Transition_Destination_Set *)*target_destination_set_ptr;
-    Transition_Destination_Set *new_tds = new Transition_Destination_Set(*original_tds); // Copy construct
+void mk_set_leaf(uint64_t* target_destination_set_ptr) {
+    auto leaf_contents_ptr = reinterpret_cast<Transition_Destination_Set**>(target_destination_set_ptr);
+
+    auto leaf_contents = *leaf_contents_ptr;
+    auto new_leaf_contents = new Transition_Destination_Set(*leaf_contents); // Copy construct
 
     // According to the GMP leaf implementation, it should suffice to just write the new value to the state_set_ptr.
-    *(Transition_Destination_Set **)target_destination_set_ptr = new_tds;
+    *leaf_contents_ptr = new_leaf_contents;
 }
 
-void destroy_set_leaf(uint64_t leaf_value)
-{
-    Transition_Destination_Set *tds = (Transition_Destination_Set *)leaf_value;
+void destroy_set_leaf(uint64_t leaf_value) {
+    auto tds = reinterpret_cast<Transition_Destination_Set*>(leaf_value);
     delete tds;
 }
 
-int set_leaf_equals(uint64_t a_ptr, uint64_t b_ptr)
-{
-    Transition_Destination_Set *a_tds = (Transition_Destination_Set *)a_ptr;
-    Transition_Destination_Set *b_tds = (Transition_Destination_Set *)b_ptr;
-
-    if ((*a_tds->destination_set) == (*b_tds->destination_set))
-    {
-        return true;
-    };
-    return false;
+int set_leaf_equals(uint64_t left_leaf_raw_ptr, uint64_t right_leaf_raw_ptr) {
+    auto left_leaf_contents  = reinterpret_cast<Transition_Destination_Set*>(left_leaf_raw_ptr);
+    auto right_leaf_contents = reinterpret_cast<Transition_Destination_Set*>(right_leaf_raw_ptr);
+    return (left_leaf_contents->destination_set == right_leaf_contents->destination_set);
 }
 
-uint64_t set_leaf_hash(const uint64_t contents_ptr, const uint64_t seed)
-{
-    Transition_Destination_Set *tds = (Transition_Destination_Set *)contents_ptr;
+uint64_t set_leaf_hash(const uint64_t leaf_contents_raw_ptr, const uint64_t seed) {
+    auto leaf_contents = reinterpret_cast<Transition_Destination_Set *>(leaf_contents_raw_ptr);
 
     const uint64_t prime = 1099511628211;
     uint64_t hash = seed;
 
-    for (auto state : *tds->destination_set) {
+    for (auto state : leaf_contents->destination_set) {
         hash = hash ^ state;
         hash = rotl64(hash, 47);
         hash = hash * prime;
@@ -68,18 +61,16 @@ uint64_t set_leaf_hash(const uint64_t contents_ptr, const uint64_t seed)
     return hash ^ (hash >> 32);
 }
 
-char *set_leaf_to_str(int comp, uint64_t leaf_val, char *buf, size_t buflen)
-{
+char* set_leaf_to_str(int comp, uint64_t leaf_contents_raw_ptr, char *buf, size_t buflen) {
     (void)comp;
+
     std::stringstream ss;
-    auto tds = (Transition_Destination_Set *)leaf_val;
+    auto leaf_contents = reinterpret_cast<Transition_Destination_Set*>(leaf_contents_raw_ptr);
     ss << "{";
     uint32_t cnt = 1;
-    for (auto i : *tds->destination_set)
-    {
+    for (auto i : leaf_contents->destination_set) {
         ss << i;
-        if (cnt < tds->destination_set->size())
-        {
+        if (cnt < leaf_contents->destination_set.size()) {
             ss << ",";
         }
         cnt++;
@@ -88,16 +79,14 @@ char *set_leaf_to_str(int comp, uint64_t leaf_val, char *buf, size_t buflen)
 
     const std::string str(ss.str());
 
-    // Does the resulting string fits into the provided buffer?
-    const size_t required_buf_size = str.size() + 1; // With nullbyte
-    if (required_buf_size <= buflen)
-    {
+    // Does the resulting string fit into the provided buffer?
+    const size_t required_buf_size = str.size() + 1; // With '\0' at the end
+    if (required_buf_size <= buflen) {
         const char *cstr = str.c_str();
         std::memcpy(buf, cstr, sizeof(char) * required_buf_size);
         return buf;
     }
-    else
-    {
+    else {
         char *new_buf = (char *)malloc(sizeof(char) * required_buf_size);
         std::memcpy(new_buf, str.c_str(), sizeof(char) * required_buf_size);
         return new_buf;

--- a/src/hopcroft_leaf.cpp
+++ b/src/hopcroft_leaf.cpp
@@ -134,7 +134,7 @@ TASK_IMPL_2(sylvan::MTBDD, hopcroft_leaf_from_normal, sylvan::MTBDD, mtbdd, uint
     Hopcroft_Leaf_Contents leaf_contents;
 
     std::map<State, std::set<State>> dest_state_to_origin_states;
-    for (State dest_state: *tds->destination_set) {
+    for (State dest_state: tds->destination_set) {
          dest_state_to_origin_states.insert({dest_state, {origin_state}});
     }
 

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -99,7 +99,6 @@ void shutdown_machinery()
 }
 
 MTBDD amaya_mtbdd_build_single_terminal(
-		uint32_t  automaton_id,
 		uint8_t*  transition_symbols,  // 2D array of size (variable_count) * transition_symbols_count
 		uint32_t  transition_symbols_count,
 		uint32_t  variable_count,
@@ -144,14 +143,12 @@ MTBDD amaya_mtbdd_build_single_terminal(
 
 MTBDD amaya_complete_mtbdd_with_trapstate(
 		MTBDD 	 dd,
-		uint32_t automaton_id,
 		State 	 trapstate,
 		bool* 	 had_effect)
 {
 
 	Complete_With_Trapstate_Op_Info op_info = {};
 	op_info.trapstate = trapstate;
-	op_info.automaton_id = automaton_id;
 	op_info.had_effect = false;
 
 	LACE_ME;
@@ -403,7 +400,6 @@ MTBDD* amaya_rename_macrostates_to_int(
 		MTBDD* 		roots, 							// MTBDDs resulting from determinization
 		uint32_t 	root_cnt,						// Root count
 		State 		start_numbering_macrostates_from,
-		uint32_t 	resulting_automaton_id,
 		State**		out_serialized_macrostates,
 		uint64_t**	out_macrostates_sizes,
 		uint64_t*	out_macrostates_cnt)
@@ -668,33 +664,14 @@ uint8_t* amaya_mtbdd_get_transitions(
 	return symbols_out;
 }
 
-void amaya_mtbdd_change_automaton_id_for_leaves(
-        MTBDD* roots,
-        uint32_t root_cnt,
-        uint32_t new_id)
-{
-	set<MTBDD> leaves {};
-    for (uint32_t i = 0; i < root_cnt; i++) {
-        collect_mtbdd_leaves(roots[i], leaves);
-    }
-
-    for (auto leaf : leaves) {
-        auto tds = (Transition_Destination_Set*) mtbdd_getvalue(leaf);
-
-		// @Refactoring:
-        // tds->automaton_id = new_id;
-    }
-}
 
 MTBDD amaya_mtbdd_intersection(
         MTBDD 		a,
         MTBDD 		b,
-        uint32_t 	result_automaton_id,
         State** 	discovered_states,         // OUT
         uint32_t*  	discovered_states_cnt)     // OUT
 {
     Intersection_Op_Info intersect_info = {0};
-    intersect_info.automaton_id = result_automaton_id;
     intersect_info.discoveries = new vector<State>();
 
 	LACE_ME;
@@ -720,9 +697,9 @@ MTBDD amaya_mtbdd_intersection(
     return result;
 }
 
-MTBDD amaya_unite_mtbdds(MTBDD m1, MTBDD m2, uint32_t automaton_id) {
+MTBDD amaya_unite_mtbdds(MTBDD m1, MTBDD m2) {
 	LACE_ME;
-	MTBDD u = mtbdd_applyp(m1, m2, (uint64_t) automaton_id, TASK(transitions_union_op), AMAYA_UNION_OP_ID);
+	MTBDD u = mtbdd_applyp(m1, m2, (uint64_t) 0, TASK(transitions_union_op), AMAYA_UNION_OP_ID);
 	return u;
 }
 


### PR DESCRIPTION
Refactor some of the issues caused by mostly me not understanding C++ well enough, or me making poor architectural decisions. Therefore, this patch gets rid of the `automaton_id` that was no longer used, and makes the `Transition_Destination_Set::destination_set` not to be a pointer anymore as it gives no value at all. 